### PR TITLE
Added 'click CTRL-C to terminate'to what is logged when app is listen…

### DIFF
--- a/server.js
+++ b/server.js
@@ -22,5 +22,5 @@ app.get('/',function(req,res){
 var port = process.env.PORT || 3000;
 
 app.listen(port, function() {
-    console.log('Server running on port 3000');
+    console.log('Server running on port 3000 press CTRL-C to terminate');
 });


### PR DESCRIPTION
I added press CTRL-C to terminate to the string logged when the app is successfully listening to the port. I made this a pull request because I couldn't figure out how to merge it without a pull request lol 😄 This is useful because I forget how to terminate the server a lot and it is good for future reference and for other people contributing!